### PR TITLE
ignore case of file extension

### DIFF
--- a/lib/client/autoform-file.coffee
+++ b/lib/client/autoform-file.coffee
@@ -34,6 +34,7 @@ getIcon = (file)->
 	icon
 
 getTemplate = (file)->
+	file = file.toLowerCase()
 	template = 'fileThumbIcon'
 	if file.indexOf('.jpg') > -1 || file.indexOf('.png') > -1 || file.indexOf('.gif') > -1
 		template = 'fileThumbImg'


### PR DESCRIPTION
Files with extensions like .JPG (capital letters) were getting directed to the wrong template.  This change adds ignoring of case in the getTemplate function, similar to the getIcon function.
