### PR TITLE
fix for collection bug after resetting form

### DIFF
--- a/lib/client/autoform-file.coffee
+++ b/lib/client/autoform-file.coffee
@@ -47,39 +47,38 @@ clearFilesFromSession = ->
 			Session.set key, ''
 
 getCollection = (context) ->
-  if typeof context.atts.collection == 'string'
-    context.atts.collection = FS._collections[context.atts.collection] or window[context.atts.collection]
-  return context.atts.collection
+	if typeof context.atts.collection == 'string'
+		context.atts.collection = FS._collections[context.atts.collection] or window[context.atts.collection]
+	return context.atts.collection
 
 AutoForm.addHooks null,
 	onSuccess: ->
 		clearFilesFromSession()
-    
+
 Template.afFileUpload.destroyed = () ->
 	name = @data.name
 	Session.set 'fileUpload['+name+']', null
 
-Template.afFileUpload.events {
-  "change .file-upload": (e, t) ->
-    files = e.target.files
-    
-    collection = getCollection(t.data)
-    collection.insert files[0], (err, fileObj) ->
-      if err
-        console.log err
-      else
-        name = $(e.target).attr('file-input')
-        # console.log $(e.target)
-        # console.log fileObj
-        $('input[name="' + name + '"]').val(fileObj._id)
-        Session.set 'fileUploadSelected[' + name + ']', files[0].name
-        # console.log fileObj
-        refreshFileInput name
-  'click .file-upload-clear': (e, t)->
-    name = $(e.currentTarget).attr('file-input')
-    $('input[name="' + name + '"]').val('')
-    Session.set 'fileUpload[' + name + ']', 'delete-file'
-}
+Template.afFileUpload.events
+	"change .file-upload": (e, t) ->
+		files = e.target.files
+
+		collection = getCollection(t.data)
+		collection.insert files[0], (err, fileObj) ->
+			if err
+				console.log err
+			else
+				name = $(e.target).attr('file-input')
+				# console.log $(e.target)
+				# console.log fileObj
+				$('input[name="' + name + '"]').val(fileObj._id)
+				Session.set 'fileUploadSelected[' + name + ']', files[0].name
+				# console.log fileObj
+				refreshFileInput name
+	'click .file-upload-clear': (e, t)->
+		name = $(e.currentTarget).attr('file-input')
+		$('input[name="' + name + '"]').val('')
+		Session.set 'fileUpload[' + name + ']', 'delete-file'
 
 Template.afFileUpload.helpers
 	collection: ->


### PR DESCRIPTION
This fixes #15 

Basically I moved the code that converts a string collection out of the template.rendered hook and into its own function. This function is then called whenever the collection is needed, and it will convert the string into the object as needed.