### PR TITLE
Fix bad parentData in afFileUpload helper

### DIFF
--- a/lib/client/autoform-file.coffee
+++ b/lib/client/autoform-file.coffee
@@ -101,12 +101,13 @@ Template.afFileUpload.helpers
 		if af &&  af.submitType == 'insert'
 			doc = af.doc
 
+		parentData = Template.parentData(0).value or Template.parentData(4).value
 		if Session.equals('fileUpload['+name+']', 'delete-file')
 			return null
 		else if Session.get('fileUpload['+name+']')
 			file = Session.get('fileUpload['+name+']')
-		else if Template.parentData(4).value
-			file = Template.parentData(4).value
+		else if parentData
+			file = parentData
 		else
 			return null
 
@@ -128,7 +129,7 @@ Template.afFileUpload.helpers
 				filename = file
 				src = filename
 		if filename
-			obj = 
+			obj =
 				template: getTemplate(filename)
 				data:
 					src: src

--- a/package.js
+++ b/package.js
@@ -1,4 +1,5 @@
 Package.describe({
+  name: "yogiben:autoform-file",
   summary: "File upload for AutoForm",
   description: "File upload for AutoForm",
   version: "0.2.0",


### PR DESCRIPTION
Working on adding file upload to this application https://github.com/modweb/grant-application
File upload was successful, but wasn't showing on the update form after upload.

Debugged and found that the `fileUpload` helper was `null`, even though the file had successfully uploaded and the autoform doc property had the GridFS object id.

I wasn't quite sure what the logic was behind `Template.parentData(4).value` so I inspected parentData at different levels and found the GridFS object id as was at the current level `Template.parentData(0).value`.

The fix looks for data at both level 4 and level 0. I presume this has to do with internals of autoform, of which I'm only slightly familiar--why would the data ever be up 4 levels?