### PR TITLE
added configurable accept attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Schemas.Posts = new SimpleSchema
 	title:
 		type:String
 		max: 60
-		
+
 	picture:
 		type: String
 		autoform:
@@ -85,4 +85,19 @@ You can customize the button / remove text.
 Defaults:
 ```
 {{> afFieldInput name="picture" label="Choose file" remove-label="Remove"}}
+```
+
+Also it is possible to customize accept attribute
+
+add it in your schema definition:
+```
+picture:
+  type: String
+  autoform:
+    afFieldInput:
+      type: 'fileUpload'
+      collection: 'Images'
+      accept: 'image/*'
+  label: 'Choose file' # optional
+
 ```

--- a/lib/client/autoform-file.coffee
+++ b/lib/client/autoform-file.coffee
@@ -87,6 +87,8 @@ Template.afFileUpload.helpers
 		@atts.label or 'Choose file'
 	removeLabel: ->
 		@atts['remove-label'] or 'Remove'
+	accept: ->		
+		@atts.accept or '*'
 	fileUploadAtts: ->
 		atts = _.clone(this.atts)
 		delete atts.collection

--- a/lib/client/autoform-file.html
+++ b/lib/client/autoform-file.html
@@ -9,7 +9,7 @@
 			{{else}}
 			<label for="file-{{name}}" class="btn btn-default">
 				{{label}}
-				<input class="hidden" id="file-{{name}}" file-input="{{name}}" type="file" />
+				<input class="hidden" id="file-{{name}}" file-input="{{name}}" type="file" accept="{{accept}}" />
 			</label>
 			{{/if}}
 			<!-- <div class="">{{> afQuickField name=name}}</div> -->


### PR DESCRIPTION
Added configurable 'accept' attribute, so it would be possible to add ``accept="image/*"`` or ``accept=".pdf"`` to filter files shown in file selector

This solves issue https://github.com/yogiben/meteor-autoform-file/issues/26 that I reported earlier