### PR TITLE
Normalize spacing on 'multiple' example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,14 @@ Schemas.Posts = new SimpleSchema
 	title:
 		type:String
 		max: 60
-
 	pictures:
 		type: [String]
-                label: 'Choose file' # optional
-        "pictures.$":
-                autoform:
-                        afFieldInput:
-                                type: 'fileUpload',
-                                collection: 'Images'
+		label: 'Choose file' # optional
+	"pictures.$":
+		autoform:
+			afFieldInput:
+				type: 'fileUpload',
+				collection: 'Images'
 ```
 
 ###Security & optimization###


### PR DESCRIPTION
Some tabs were spaces and displaying incorrectly (though not in editor).  Converted to tabs.