### PR TITLE
Add event listeners for file drop support on button area.

### DIFF
--- a/lib/client/autoform-file.coffee
+++ b/lib/client/autoform-file.coffee
@@ -62,6 +62,27 @@ Template.afFileUpload.events
       if err then return console.log err
       t.value.set fileObj._id
 
+  "dragover .js-select-file": (e) ->
+    e.stopPropagation()
+    e.preventDefault()
+    
+  "dragenter .js-select-file": (e) ->
+    e.stopPropagation()
+    e.preventDefault()
+
+  "drop .js-select-file": (e, t) ->
+    e.stopPropagation();
+    e.preventDefault();
+    collection = getCollection t.data
+
+    file = new FS.File e.originalEvent.dataTransfer.files[0]
+    if Meteor.userId
+      file.owner = Meteor.userId()
+
+    collection.insert file, (err, fileObj) ->
+      if err then return console.log err
+      t.value.set fileObj._id
+
   'click .js-remove': (e, t) ->
     e.preventDefault()
     t.value.set null

--- a/package.js
+++ b/package.js
@@ -14,7 +14,7 @@ Package.onUse(function(api) {
     'underscore',
     'reactive-var',
     'templating',
-    'less',
+    'less@1.0.0 || 2.5.0',
     'aldeed:autoform@5.4.0',
     'fortawesome:fontawesome@4.4.0'
   ]);


### PR DESCRIPTION
File drop support is added by listening to `dragover`, `dragenter` and `drop` events by using the same `change` event handler code.
you can style file upload button to make a file drop area.