### PR TITLE
Updated less dependency for Meteor 1.2 (also backcompat)

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,7 +14,7 @@ Package.onUse(function(api) {
     'underscore',
     'reactive-var',
     'templating',
-    'less',
+    'less@1.0.0 || 2.5.0',
     'aldeed:autoform@5.4.0',
     'fortawesome:fontawesome@4.4.0'
   ]);


### PR DESCRIPTION
I updated the less dependency so that it will work with Meteor 1.2, also kept Meteor less than 1.2 working.