### PR TITLE
Fixed #69 bug

### DIFF
--- a/lib/client/autoform-file.coffee
+++ b/lib/client/autoform-file.coffee
@@ -16,14 +16,6 @@ Template.afFileUpload.onCreated ->
   self = @
   @value = new ReactiveVar @data.value
 
-  @_stopInterceptValue = false
-  @_interceptValue = (ctx) =>
-    unless @_stopInterceptValue
-      t = Template.instance()
-      if t.value.get() isnt false and t.value.get() isnt ctx.value
-        t.value.set ctx.value
-        @_stopInterceptValue = true
-
   @_insert = (file) ->
     collection = getCollection self.data
 
@@ -65,7 +57,6 @@ Template.afFileUpload.helpers
     file: getDocument @
     atts: @atts
   file: ->
-    Template.instance()._interceptValue @
     getDocument @
   removeFileBtnTemplate: ->
     @atts?.removeFileBtnTemplate or 'afFileRemoveFileBtnTemplate'


### PR DESCRIPTION
Seems the file is uploaded and saved successfully, but overwrite by the empty ctx.value. [code](https://github.com/yogiben/meteor-autoform-file/blob/master/lib/client/autoform-file.coffee#L24)

- Fixed #69 bug

And the warning "'undefined' is not a valid enum" maybe the CFS warning.
https://github.com/CollectionFS/Meteor-CollectionFS/issues/688

https://github.com/yogiben/meteor-autoform-file/commit/7c6616b9508f3e514040f7ad20709c76f8d88925 Actually I don't know which bug wants to be fixed, so I removed the code. 
