### PR TITLE
meteor package accounts-password added

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "yogiben:autoform-file",
-  summary: "File upload for AutoForm",
-  description: "File upload for AutoForm",
+  summary: "File upload for AutoForm (LOCALY)",
+  description: "File upload for AutoForm (LOCALY)",
   version: "0.4.1",
   git: "https://github.com/yogiben/autoform-file.git"
 });
@@ -19,7 +19,8 @@ Package.onUse(function(api) {
     'aldeed:autoform@5.5.1',
     'fortawesome:fontawesome@4.5.0',
     'cfs:ui@0.1.3',
-    'mpowaga:jquery-fileupload@9.11.2'
+    'mpowaga:jquery-fileupload@9.11.2',
+    'accounts-password'
   ]);
 
   api.addFiles('lib/client/autoform-file.html', 'client');

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "yogiben:autoform-file",
-  summary: "File upload for AutoForm (LOCALY)",
-  description: "File upload for AutoForm (LOCALY)",
+  summary: "File upload for AutoForm",
+  description: "File upload for AutoForm",
   version: "0.4.1",
   git: "https://github.com/yogiben/autoform-file.git"
 });


### PR DESCRIPTION
package accounts-password has to be added in dependency list (api.use) otherwise this kind of exception will be thrown by choosing image 

```
Exception in delivering result of invoking '/cfs.locationIcon.filerecord/insert': TypeError: Meteor.userId is not a function
    at http://localhost:3000/packages/yogiben_autoform-file.js?fd125e956e096bb4e5228a39d05114e4babda192:245:27
    at http://localhost:3000/packages/cfs_collection.js?60aba0a5a61bd74237ef18bbd254c4c42a4b3cbb:282:9
    at wrappedCallback (http://localhost:3000/packages/mongo.js?69942a86515ec397dfd8cbb0a151a0eefdd9560d:629:9)
    at null._callback (http://localhost:3000/packages/meteor.js?9730f4ff059088b3f7f14c0672d155218a1802d4:999:22)
    at _.extend._maybeInvokeCallback (http://localhost:3000/packages/ddp-client.js?82da06d8e1ea6342d823b2c5c3be071e96108c70:3508:12)
    at _.extend.dataVisible (http://localhost:3000/packages/ddp-client.js?82da06d8e1ea6342d823b2c5c3be071e96108c70:3537:10)
    at http://localhost:3000/packages/ddp-client.js?82da06d8e1ea6342d823b2c5c3be071e96108c70:4373:7
    at Array.forEach (native)
    at Function._.each._.forEach (http://localhost:3000/packages/underscore.js?fa590de5090ceb4a42555b48562fd8f8e7035758:157:11)
    at _.extend._runAfterUpdateCallbacks (http://localhost:3000/packages/ddp-client.js?82da06d8e1ea6342d823b2c5c3be071e96108c70:4372:7)
```
