### PR TITLE
Including 'name' in the input

### DIFF
--- a/lib/client/autoform-file.html
+++ b/lib/client/autoform-file.html
@@ -10,7 +10,7 @@
     {{else}}
       {{> Template.dynamic template=selectFileBtnTemplate data=selectFileBtnData}}
     {{/if}}
-    <input type="hidden" class="js-value" value="{{value}}" data-schema-key="{{schemaKey}}">
+    <input type="hidden" class="js-value" value="{{value}}" data-schema-key="{{schemaKey}}" name="{{schemaKey}}">
   </div>
 </template>
 


### PR DESCRIPTION
In aldeed's auto form, it seems to like the 'name' attribute in the input element.  

I just did a simple mod, and this worked when you include the afFieldInput in an {{>autoForm ... }}
