### PR TITLE
jQuery not defined as $

### DIFF
--- a/lib/client/autoform-file.coffee
+++ b/lib/client/autoform-file.coffee
@@ -48,7 +48,8 @@ Template.afFileUpload.onCreated ->
 
 Template.afFileUpload.onRendered ->
   self = @
-  $(self.firstNode).closest('form').on 'reset', ->
+  jq = $ or jQuery
+  jq(self.firstNode).closest('form').on 'reset', ->
     self.value.set false
 
 Template.afFileUpload.helpers
@@ -119,4 +120,5 @@ Template.afFileUploadThumbIcon.helpers
         'file-o'
 
 Template.afFileSelectFileBtnTemplate.onRendered ->
-  @$('.js-file').fileupload()
+  jq = $ or jQuery
+  jq('.js-file').fileupload()


### PR DESCRIPTION
Trying to use this with meteor 1.2.1 and I'm getting errors in the console that $ is undefined.

```
TypeError: $ is not a function
    at null.<anonymous> (autoform-file.coffee:52)
    at template.js:116
    at Function.Template._withTemplateInstanceFunc (template.js:457)
    at fireCallbacks (template.js:112)
    at null.<anonymous> (template.js:205)
    at view.js:107
    at Object.Blaze._withCurrentView (view.js:538)
    at view.js:106
    at Object.Tracker._runFlush (tracker.js:497)
    at onGlobalMessage (setimmediate.js:102)
```

Testing manually in the console gives this

```
$(document)
VM6976:2 Uncaught TypeError: $ is not a function(…)
jQuery(document)
[#document]
```

This small fix solves the issue for me and should be fully compatible however jQuery is exported/defined
